### PR TITLE
Fix self-closing <div> that was causing Vite warning

### DIFF
--- a/src/lib/svelte-echarts/components/Chart.svelte
+++ b/src/lib/svelte-echarts/components/Chart.svelte
@@ -55,4 +55,4 @@
 </script>
 
 <!-- restProps is currently broken with typescript -->
-<div bind:this={element} style="width: 100%; height: 100%" {...$$restProps} />
+<div bind:this={element} style="width: 100%; height: 100%" {...$$restProps}></div>


### PR DESCRIPTION
Fixed self-closing `<div>` tag that was causing Vite to warn `Self-closing HTML tags for non-void elements are ambiguous — use <div ...></div> rather than <div ... />`